### PR TITLE
Add framing-agnostic TCP transport support

### DIFF
--- a/LeanWorker/Framing.lean
+++ b/LeanWorker/Framing.lean
@@ -3,5 +3,6 @@ module
 public import LeanWorker.Framing.Parse
 public import LeanWorker.Framing.Newline
 public import LeanWorker.Framing.ContentLength
+public import LeanWorker.Framing.Spec
 
 public section

--- a/LeanWorker/Framing/ContentLength.lean
+++ b/LeanWorker/Framing/ContentLength.lean
@@ -49,6 +49,26 @@ def decodeContentLengthBytes
     (buffer : ByteArray) : Except Error (Array ByteArray × ByteArray) :=
   decodeContentLengthAux buffer #[]
 
+def pullContentLengthPayload?
+    (buffer : ByteArray) : Except Error (Option (ByteArray × ByteArray)) := do
+  match findHeaderTerminator buffer with
+  | none =>
+    return none
+  | some headerEnd => do
+    let bodyStart := headerEnd + 4
+    let headerBytes := buffer.extract 0 headerEnd
+    let headerText ←
+      match String.fromUTF8? headerBytes with
+      | some text => Except.ok text
+      | none => Except.error (framingError "invalid UTF-8 in headers")
+    let headers ← parseHeaders headerText
+    let contentLength ← parseContentLength headers
+    if buffer.size < bodyStart + contentLength then
+      return none
+    let bodyBytes := buffer.extract bodyStart (bodyStart + contentLength)
+    let rest := buffer.extract (bodyStart + contentLength) buffer.size
+    return some (bodyBytes, rest)
+
 def encodeContentLengthBytes (payload : ByteArray) : ByteArray :=
   let header := s!"Content-Length: {payload.size}\r\n\r\n"
   header.toUTF8 ++ payload

--- a/LeanWorker/Framing/Newline.lean
+++ b/LeanWorker/Framing/Newline.lean
@@ -38,6 +38,28 @@ private partial def decodeNewlineAux
 def decodeNewlineBytes (buffer : ByteArray) : Except Error (Array ByteArray × ByteArray) :=
   decodeNewlineAux buffer 0 0 #[]
 
+private partial def pullNewlinePayloadAux
+    (buffer : ByteArray)
+    (index : Nat)
+    (start : Nat) : Except Error (Option (ByteArray × ByteArray)) := do
+  if index < buffer.size then
+    if buffer.get! index == (10 : UInt8) then
+      let rawLine := buffer.extract start index
+      let line := dropTrailingCR rawLine
+      let nextStart := index + 1
+      if line.size == 0 then
+        pullNewlinePayloadAux buffer nextStart nextStart
+      else
+        let rest := buffer.extract nextStart buffer.size
+        return some (line, rest)
+    else
+      pullNewlinePayloadAux buffer (index + 1) start
+  else
+    return none
+
+def pullNewlinePayload? (buffer : ByteArray) : Except Error (Option (ByteArray × ByteArray)) :=
+  pullNewlinePayloadAux buffer 0 0
+
 def encodeNewlineBytes (payload : ByteArray) : ByteArray :=
   payload ++ "\n".toUTF8
 

--- a/LeanWorker/Framing/Spec.lean
+++ b/LeanWorker/Framing/Spec.lean
@@ -19,6 +19,7 @@ inductive Spec where
 structure Codec where
   encode : ByteArray → ByteArray
   decode : ByteArray → Except Error (Array ByteArray × ByteArray)
+  pullPayload? : ByteArray → Except Error (Option (ByteArray × ByteArray))
   eofError : Error
 
 private def eofErrorFor : Spec → Error
@@ -30,12 +31,14 @@ def codec : Spec → Codec
     {
       encode := encodeNewlineBytes
       decode := decodeNewlineBytes
+      pullPayload? := pullNewlinePayload?
       eofError := eofErrorFor .newline
     }
   | .contentLength =>
     {
       encode := encodeContentLengthBytes
       decode := decodeContentLengthBytes
+      pullPayload? := pullContentLengthPayload?
       eofError := eofErrorFor .contentLength
     }
 
@@ -45,6 +48,10 @@ def codec : Spec → Codec
 @[inline] def decode
     (spec : Spec) : ByteArray → Except Error (Array ByteArray × ByteArray) :=
   (codec spec).decode
+
+@[inline] def pullPayload?
+    (spec : Spec) : ByteArray → Except Error (Option (ByteArray × ByteArray)) :=
+  (codec spec).pullPayload?
 
 @[inline] def eofError (spec : Spec) : Error :=
   (codec spec).eofError

--- a/LeanWorker/Framing/Spec.lean
+++ b/LeanWorker/Framing/Spec.lean
@@ -1,0 +1,53 @@
+module
+
+public import LeanWorker.Framing.Newline
+public import LeanWorker.Framing.ContentLength
+
+public section
+
+namespace LeanWorker
+namespace Framing
+
+open Lean
+open JsonRpc
+
+inductive Spec where
+  | newline
+  | contentLength
+ deriving BEq, Repr, Inhabited
+
+structure Codec where
+  encode : ByteArray → ByteArray
+  decode : ByteArray → Except Error (Array ByteArray × ByteArray)
+  eofError : Error
+
+private def eofErrorFor : Spec → Error
+  | .newline => framingError "unexpected EOF while reading newline-framed payload"
+  | .contentLength => framingError "unexpected EOF while reading content-length-framed payload"
+
+def codec : Spec → Codec
+  | .newline =>
+    {
+      encode := encodeNewlineBytes
+      decode := decodeNewlineBytes
+      eofError := eofErrorFor .newline
+    }
+  | .contentLength =>
+    {
+      encode := encodeContentLengthBytes
+      decode := decodeContentLengthBytes
+      eofError := eofErrorFor .contentLength
+    }
+
+@[inline] def encode (spec : Spec) : ByteArray → ByteArray :=
+  (codec spec).encode
+
+@[inline] def decode
+    (spec : Spec) : ByteArray → Except Error (Array ByteArray × ByteArray) :=
+  (codec spec).decode
+
+@[inline] def eofError (spec : Spec) : Error :=
+  (codec spec).eofError
+
+end Framing
+end LeanWorker

--- a/LeanWorker/Server/Run.lean
+++ b/LeanWorker/Server/Run.lean
@@ -20,6 +20,7 @@ def run (server : Server Context State) (ctx : Context) (state : Std.Mutex State
   let remainingTasks ← mainLoop state
   for task in remainingTasks do
     await task
+  LeanWorker.Transport.closeOrLog server.transport.log "server outbox" server.transport.outbox
 where
   filterTasks (tasks : Array (AsyncTask Unit)) : BaseIO (Array (AsyncTask Unit)) :=
     tasks.filterM fun task => return (← task.getState) != .finished

--- a/LeanWorker/Transport.lean
+++ b/LeanWorker/Transport.lean
@@ -2,6 +2,8 @@ module
 
 public import LeanWorker.Transport.Types
 public import LeanWorker.Transport.Logging
+public import LeanWorker.Transport.Core
 public import LeanWorker.Transport.Stdio
+public import LeanWorker.Transport.Tcp
 
 public section

--- a/LeanWorker/Transport/Core.lean
+++ b/LeanWorker/Transport/Core.lean
@@ -64,6 +64,23 @@ private def emitPayloads
           continueLoop := false
   return continueLoop
 
+private partial def drainFramedPayloads
+    (codec : Framing.Codec)
+    (log : LogLevel → String → IO Unit)
+    (inbox : Std.CloseableChannel (Except Error Json))
+    (buffer : ByteArray) : Async (Except Error (Bool × ByteArray)) := do
+  match codec.pullPayload? buffer with
+  | .error err =>
+    return .error err
+  | .ok none =>
+    return .ok (true, buffer)
+  | .ok (some (payload, rest)) =>
+    let keepReading ← emitPayloads log inbox #[payload]
+    if keepReading then
+      drainFramedPayloads codec log inbox rest
+    else
+      return .ok (false, rest)
+
 private partial def readJsonLoop
     (source : ByteSource)
     (codec : Framing.Codec)
@@ -79,15 +96,14 @@ private partial def readJsonLoop
       if sent then
         LeanWorker.Transport.closeOrLog log "json inbox" inbox
   | some chunk =>
-    match codec.decode (buffer ++ chunk) with
+    match ← drainFramedPayloads codec log inbox (buffer ++ chunk) with
     | .error err =>
       LeanWorker.Transport.logError log
         s!"framing decode error: {LeanWorker.Transport.errorToString err}"
       let sent ← LeanWorker.Transport.sendOrLog log "json inbox" inbox (.error err)
       if sent then
         readJsonLoop source codec log inbox ByteArray.empty
-    | .ok (payloads, rest) =>
-      let keepReading ← emitPayloads log inbox payloads
+    | .ok (keepReading, rest) =>
       if keepReading then
         readJsonLoop source codec log inbox rest
 

--- a/LeanWorker/Transport/Core.lean
+++ b/LeanWorker/Transport/Core.lean
@@ -1,0 +1,140 @@
+module
+
+public import LeanWorker.Transport.Logging
+public import LeanWorker.Framing
+public import LeanWorker.JsonRpc.Parse
+public import Std.Internal.Async.Basic
+
+public section
+
+namespace LeanWorker
+namespace Transport
+
+open Lean
+open JsonRpc
+open Std.Internal.IO.Async
+
+private def readChunkSize : Nat := 4096
+
+structure ByteSource where
+  recv? : Nat → Async (Option ByteArray)
+
+structure ByteSink where
+  send : ByteArray → Async Unit
+  flush : Async Unit := pure ()
+  shutdown : Async Unit := pure ()
+
+private def decodeJsonPayload (payload : ByteArray) : Except Error Json := do
+  let text ←
+    match String.fromUTF8? payload with
+    | some text => Except.ok text
+    | none =>
+      throw <| Error.withData Error.parseError (Json.str "invalid UTF-8 in JSON payload")
+  parseJson text
+
+private def encodeJsonPayload (json : Json) : ByteArray :=
+  (Json.compress json).toUTF8
+
+private def writeFramedJson
+    (sink : ByteSink)
+    (codec : Framing.Codec)
+    (json : Json) : Async Unit := do
+  let payload := encodeJsonPayload json
+  let bytes := codec.encode payload
+  sink.send bytes
+  sink.flush
+
+private def emitPayloads
+    (log : LogLevel → String → IO Unit)
+    (inbox : Std.CloseableChannel (Except Error Json))
+    (payloads : Array ByteArray) : Async Bool := do
+  let mut continueLoop := true
+  for payload in payloads do
+    if continueLoop then
+      match decodeJsonPayload payload with
+      | .ok json =>
+        let sent ← LeanWorker.Transport.sendOrLog log "json inbox" inbox (.ok json)
+        if !sent then
+          continueLoop := false
+      | .error err =>
+        LeanWorker.Transport.logError log
+          s!"json decode error: {LeanWorker.Transport.errorToString err}"
+        let sent ← LeanWorker.Transport.sendOrLog log "json inbox" inbox (.error err)
+        if !sent then
+          continueLoop := false
+  return continueLoop
+
+private partial def readJsonLoop
+    (source : ByteSource)
+    (codec : Framing.Codec)
+    (log : LogLevel → String → IO Unit)
+    (inbox : Std.CloseableChannel (Except Error Json))
+    (buffer : ByteArray := ByteArray.empty) : Async Unit := do
+  match ← source.recv? readChunkSize with
+  | none =>
+    if buffer.isEmpty then
+      LeanWorker.Transport.closeOrLog log "json inbox" inbox
+    else
+      let sent ← LeanWorker.Transport.sendOrLog log "json inbox" inbox (.error codec.eofError)
+      if sent then
+        LeanWorker.Transport.closeOrLog log "json inbox" inbox
+  | some chunk =>
+    match codec.decode (buffer ++ chunk) with
+    | .error err =>
+      LeanWorker.Transport.logError log
+        s!"framing decode error: {LeanWorker.Transport.errorToString err}"
+      let sent ← LeanWorker.Transport.sendOrLog log "json inbox" inbox (.error err)
+      if sent then
+        readJsonLoop source codec log inbox ByteArray.empty
+    | .ok (payloads, rest) =>
+      let keepReading ← emitPayloads log inbox payloads
+      if keepReading then
+        readJsonLoop source codec log inbox rest
+
+private partial def writeJsonLoop
+    (sink : ByteSink)
+    (codec : Framing.Codec)
+    (outbox : Std.CloseableChannel Json) : Async Unit := do
+  match ← await <| ← outbox.recv with
+  | none =>
+    sink.flush
+    sink.shutdown
+  | some json =>
+    writeFramedJson sink codec json
+    writeJsonLoop sink codec outbox
+
+private def transportFromByteStreamsCore
+    (source : ByteSource)
+    (sink : ByteSink)
+    (framing : Framing.Spec)
+    (log : LogLevel → String → IO Unit) : Async Transport := do
+  let inbox : Std.CloseableChannel (Except Error Json) ← Std.CloseableChannel.new
+  let outbox : Std.CloseableChannel Json ← Std.CloseableChannel.new
+  let codec := Framing.codec framing
+
+  let _readerTask : AsyncTask Unit ← async do
+    try
+      readJsonLoop source codec log inbox
+    catch err =>
+      LeanWorker.Transport.logError log s!"json read task error: {err}"
+      LeanWorker.Transport.closeOrLog log "json inbox" inbox
+
+  let _writerTask : AsyncTask Unit ← async do
+    try
+      writeJsonLoop sink codec outbox
+    catch err =>
+      LeanWorker.Transport.logError log s!"json write task error: {err}"
+      LeanWorker.Transport.closeOrLog log "json outbox" outbox
+      LeanWorker.Transport.closeOrLog log "json inbox" inbox
+
+  return { inbox, outbox, log }
+
+def transportFromByteStreams
+    (source : ByteSource)
+    (sink : ByteSink)
+    (framing : Framing.Spec := .newline)
+    (log : LogLevel → String → IO Unit := silentLogger) : Async Transport :=
+  transportFromByteStreamsCore source sink framing log
+
+end Transport
+end LeanWorker

--- a/LeanWorker/Transport/Stdio.lean
+++ b/LeanWorker/Transport/Stdio.lean
@@ -1,7 +1,6 @@
 module
 
-public import LeanWorker.Transport.Types
-public import LeanWorker.Transport.Logging
+public import LeanWorker.Transport.Core
 public import LeanWorker.Framing
 public import LeanWorker.JsonRpc.Parse
 public import Std.Internal.Async.Basic
@@ -17,23 +16,6 @@ open Std.Internal.IO.Async
 
 private def readChunkSize : Nat := 4096
 
-inductive FrameSpec where
-  | newline
-  | contentLength
-deriving BEq, Repr, Inhabited
-
-private def encodeFrame (frameSpec : FrameSpec) : ByteArray → ByteArray :=
-  match frameSpec with
-  | .newline => Framing.encodeNewlineBytes
-  | .contentLength => Framing.encodeContentLengthBytes
-
-private def decodeFrame
-    (frameSpec : FrameSpec) :
-    ByteArray → Except Error (Array ByteArray × ByteArray) :=
-  match frameSpec with
-  | .newline => Framing.decodeNewlineBytes
-  | .contentLength => Framing.decodeContentLengthBytes
-
 private def decodeJsonPayload (payload : ByteArray) : Except Error Json := do
   let text ←
     match String.fromUTF8? payload with
@@ -45,17 +27,12 @@ private def decodeJsonPayload (payload : ByteArray) : Except Error Json := do
 private def encodeJsonPayload (json : Json) : ByteArray :=
   (Json.compress json).toUTF8
 
-private def eofFramingError (frameSpec : FrameSpec) : Error :=
-  match frameSpec with
-  | .newline => Framing.framingError "unexpected EOF while reading newline-framed payload"
-  | .contentLength => Framing.framingError "unexpected EOF while reading content-length-framed payload"
-
 private def writeFramedJson
     (writeStream : IO.FS.Stream)
-    (frameSpec : FrameSpec)
+    (framing : Framing.Spec)
     (json : Json) : IO Unit := do
   let payload := encodeJsonPayload json
-  let bytes := encodeFrame frameSpec payload
+  let bytes := Framing.encode framing payload
   writeStream.write bytes
   writeStream.flush
 
@@ -122,13 +99,12 @@ private partial def readNewlineLoop
     if buffer.isEmpty then
       LeanWorker.Transport.closeOrLog log "json inbox" inbox
     else
-      let err := eofFramingError .newline
-      let sent ← LeanWorker.Transport.sendOrLog log "json inbox" inbox (.error err)
+      let sent ← LeanWorker.Transport.sendOrLog log "json inbox" inbox (.error <| Framing.eofError .newline)
       if sent then
         LeanWorker.Transport.closeOrLog log "json inbox" inbox
   else
     let buffer := buffer ++ line.toUTF8
-    match decodeFrame .newline buffer with
+    match Framing.decode .newline buffer with
     | .error err =>
       LeanWorker.Transport.logError log
         s!"framing decode error: {LeanWorker.Transport.errorToString err}"
@@ -176,41 +152,41 @@ private partial def readContentLengthLoop
 
 private def readJsonLoop
     (readStream : IO.FS.Stream)
-    (frameSpec : FrameSpec)
+    (framing : Framing.Spec)
     (log : LogLevel → String → IO Unit)
     (inbox : Std.CloseableChannel (Except Error Json)) : Async Unit :=
-  match frameSpec with
+  match framing with
   | .newline => readNewlineLoop readStream log inbox
   | .contentLength => readContentLengthLoop readStream log inbox
 
 private partial def writeJsonLoop
     (writeStream : IO.FS.Stream)
-    (frameSpec : FrameSpec)
+    (framing : Framing.Spec)
     (outbox : Std.CloseableChannel Json) : Async Unit := do
   match ← await <| ← outbox.recv with
   | none =>
     return
   | some json =>
-    writeFramedJson writeStream frameSpec json
-    writeJsonLoop writeStream frameSpec outbox
+    writeFramedJson writeStream framing json
+    writeJsonLoop writeStream framing outbox
 
 private def transportFromStreamsCore
     (readStream writeStream : IO.FS.Stream)
-    (frameSpec : FrameSpec)
+    (framing : Framing.Spec)
     (log : LogLevel → String → IO Unit) : Async Transport := do
   let inbox : Std.CloseableChannel (Except Error Json) ← Std.CloseableChannel.new
   let outbox : Std.CloseableChannel Json ← Std.CloseableChannel.new
 
   let _readerTask : AsyncTask Unit ← async do
     try
-      readJsonLoop readStream frameSpec log inbox
+      readJsonLoop readStream framing log inbox
     catch err =>
       LeanWorker.Transport.logError log s!"json read task error: {err}"
       LeanWorker.Transport.closeOrLog log "json inbox" inbox
 
   let _writerTask : AsyncTask Unit ← async do
     try
-      writeJsonLoop writeStream frameSpec outbox
+      writeJsonLoop writeStream framing outbox
     catch err =>
       LeanWorker.Transport.logError log s!"json write task error: {err}"
       LeanWorker.Transport.closeOrLog log "json outbox" outbox
@@ -220,35 +196,35 @@ private def transportFromStreamsCore
 
 def transportFromStreams
     (readStream writeStream : IO.FS.Stream)
-    (frameSpec : FrameSpec := .newline)
+    (framing : Framing.Spec := .newline)
     (log : LogLevel → String → IO Unit := silentLogger) : Async Transport :=
-  transportFromStreamsCore readStream writeStream frameSpec log
+  transportFromStreamsCore readStream writeStream framing log
 
 def serverTransportFromStreams
     (readStream writeStream : IO.FS.Stream)
-    (frameSpec : FrameSpec := .newline)
+    (framing : Framing.Spec := .newline)
     (log : LogLevel → String → IO Unit := silentLogger) : Async Transport :=
-  transportFromStreams readStream writeStream frameSpec log
+  transportFromStreams readStream writeStream framing log
 
 def clientTransportFromStreams
     (readStream writeStream : IO.FS.Stream)
-    (frameSpec : FrameSpec := .newline)
+    (framing : Framing.Spec := .newline)
     (log : LogLevel → String → IO Unit := silentLogger) : Async Transport :=
-  transportFromStreams readStream writeStream frameSpec log
+  transportFromStreams readStream writeStream framing log
 
 def serverTransportFromStdio
-    (frameSpec : FrameSpec := .newline)
+    (framing : Framing.Spec := .newline)
     (log : LogLevel → String → IO Unit := silentLogger) : Async Transport := do
   let stdin ← IO.getStdin
   let stdout ← IO.getStdout
-  serverTransportFromStreams stdin stdout frameSpec log
+  serverTransportFromStreams stdin stdout framing log
 
 def clientTransportFromStdio
-    (frameSpec : FrameSpec := .newline)
+    (framing : Framing.Spec := .newline)
     (log : LogLevel → String → IO Unit := silentLogger) : Async Transport := do
   let stdin ← IO.getStdin
   let stdout ← IO.getStdout
-  clientTransportFromStreams stdin stdout frameSpec log
+  clientTransportFromStreams stdin stdout framing log
 
 end Transport
 end LeanWorker

--- a/LeanWorker/Transport/Tcp.lean
+++ b/LeanWorker/Transport/Tcp.lean
@@ -1,0 +1,126 @@
+module
+
+public import LeanWorker.Transport.Core
+public import Std.Internal.Async.TCP
+public import Std.Internal.Async.DNS
+
+public section
+
+namespace LeanWorker
+namespace Transport
+
+open Std.Net
+open Std.Internal.IO.Async
+
+abbrev TcpServerSocket := Std.Internal.IO.Async.TCP.Socket.Server
+abbrev TcpClientSocket := Std.Internal.IO.Async.TCP.Socket.Client
+
+structure TcpEndpoint where
+  host : String
+  port : UInt16
+  family? : Option AddressFamily := none
+
+private def byteSourceOfTcpSocket (socket : TcpClientSocket) : ByteSource where
+  recv? maxBytes :=
+    socket.recv? (UInt64.ofNat maxBytes)
+
+private def byteSinkOfTcpSocket (socket : TcpClientSocket) : ByteSink where
+  send bytes :=
+    socket.send bytes
+  shutdown :=
+    socket.shutdown
+
+private def serviceName (port : UInt16) : String :=
+  toString port.toNat
+
+def ipAddrToSocketAddress (ipAddr : IPAddr) (port : UInt16) : SocketAddress :=
+  match ipAddr with
+  | .v4 addr => .v4 { addr, port }
+  | .v6 addr => .v6 { addr, port }
+
+-- TODO: move upstream if Lean adds a `ToString SocketAddress` instance.
+def socketAddressToString : SocketAddress → String
+  | .v4 addr => s!"{addr.addr}:{addr.port.toNat}"
+  | .v6 addr => s!"[{addr.addr}]:{addr.port.toNat}"
+
+def transportFromTcpSocket
+    (socket : TcpClientSocket)
+    (framing : Framing.Spec := .newline)
+    (log : LogLevel → String → IO Unit := silentLogger) : Async Transport :=
+  transportFromByteStreams
+    (byteSourceOfTcpSocket socket)
+    (byteSinkOfTcpSocket socket)
+    framing
+    log
+
+def serverTransportFromAcceptedTcpSocket
+    (socket : TcpClientSocket)
+    (framing : Framing.Spec := .newline)
+    (log : LogLevel → String → IO Unit := silentLogger) : Async Transport :=
+  transportFromTcpSocket socket framing log
+
+def clientTransportFromTcpAddress
+    (addr : SocketAddress)
+    (framing : Framing.Spec := .newline)
+    (log : LogLevel → String → IO Unit := silentLogger) : Async Transport := do
+  let socket ← TCP.Socket.Client.mk
+  LeanWorker.Transport.logAsync log .info s!"connecting tcp client to {socketAddressToString addr}"
+  socket.connect addr
+  let peerAddr ← socket.getPeerName
+  LeanWorker.Transport.logAsync log .info
+    s!"connected tcp client to {socketAddressToString peerAddr}"
+  transportFromTcpSocket socket framing log
+
+private partial def connectResolvedAddresses
+    (addresses : List SocketAddress)
+    (framing : Framing.Spec)
+    (log : LogLevel → String → IO Unit) : Async Transport := do
+  match addresses with
+  | [] =>
+    throw <| IO.userError "no tcp addresses available for connection"
+  | addr :: rest =>
+    try
+      clientTransportFromTcpAddress addr framing log
+    catch err =>
+      LeanWorker.Transport.logAsync log .warn
+        s!"tcp connect failed for {socketAddressToString addr}: {err}"
+      match rest with
+      | [] => throw err
+      | _ => connectResolvedAddresses rest framing log
+
+def clientTransportFromTcp
+    (endpoint : TcpEndpoint)
+    (framing : Framing.Spec := .newline)
+    (log : LogLevel → String → IO Unit := silentLogger) : Async Transport := do
+  LeanWorker.Transport.logAsync log .info
+    s!"resolving tcp endpoint {endpoint.host}:{endpoint.port.toNat}"
+  let addresses ← Std.Internal.IO.Async.DNS.getAddrInfo
+    endpoint.host
+    (serviceName endpoint.port)
+    endpoint.family?
+  let addresses := addresses.toList.map fun addr => ipAddrToSocketAddress addr endpoint.port
+  if addresses.isEmpty then
+    throw <| IO.userError s!"no tcp addresses resolved for {endpoint.host}:{endpoint.port.toNat}"
+  connectResolvedAddresses addresses framing log
+
+def serverTransportFromTcpAddress
+    (addr : SocketAddress)
+    (framing : Framing.Spec := .newline)
+    (log : LogLevel → String → IO Unit := silentLogger)
+    (backlog : UInt32 := 16) : Async Transport := do
+  let server ← TCP.Socket.Server.mk
+  LeanWorker.Transport.logAsync log .info
+    s!"binding tcp server to {socketAddressToString addr}"
+  server.bind addr
+  server.listen backlog
+  let localAddr ← server.getSockName
+  LeanWorker.Transport.logAsync log .info
+    s!"tcp server listening on {socketAddressToString localAddr}"
+  let socket ← server.accept
+  let peerAddr ← socket.getPeerName
+  LeanWorker.Transport.logAsync log .info
+    s!"accepted tcp client from {socketAddressToString peerAddr}"
+  serverTransportFromAcceptedTcpSocket socket framing log
+
+end Transport
+end LeanWorker

--- a/LeanWorkerTest/TestClient.lean
+++ b/LeanWorkerTest/TestClient.lean
@@ -49,6 +49,7 @@ private def serverFrameArg (framing : Framing.Spec) : String :=
   | .contentLength => "--header"
 
 private def spawnTestServer (framing : Framing.Spec) : IO (SpawnedServer × IO.FS.Stream × IO.FS.Stream) := do
+  -- This assumes the test is run from the repo root after `lake build`.
   let child ← IO.Process.spawn {
     cmd := ".lake/build/bin/test_server"
     args := #[serverFrameArg framing]

--- a/LeanWorkerTest/TestClient.lean
+++ b/LeanWorkerTest/TestClient.lean
@@ -2,6 +2,7 @@ module
 
 import LeanWorker.Client
 import LeanWorker.Transport
+import LeanWorker.Framing
 
 namespace LeanWorkerTest
 
@@ -9,14 +10,15 @@ open Lean
 open LeanWorker
 open Client
 open Transport
+open Framing
 open JsonRpc
 open Std.Internal.IO.Async
 
 private abbrev SpawnedServer :=
   IO.Process.Child { stdin := .null, stdout := .piped, stderr := .inherit }
 
-private def parseFrameSpec (args : List String) : Except String FrameSpec := do
-  let mut selected? : Option FrameSpec := none
+private def parseFrameSpec (args : List String) : Except String Framing.Spec := do
+  let mut selected? : Option Framing.Spec := none
   for arg in args do
     match arg with
     | "--" =>
@@ -41,15 +43,15 @@ private def parseFrameSpec (args : List String) : Except String FrameSpec := do
       throw s!"unknown flag: {arg}"
   return selected?.getD .newline
 
-private def serverFrameArg (frameSpec : FrameSpec) : String :=
-  match frameSpec with
+private def serverFrameArg (framing : Framing.Spec) : String :=
+  match framing with
   | .newline => "--newline"
   | .contentLength => "--header"
 
-private def spawnTestServer (frameSpec : FrameSpec) : IO (SpawnedServer × IO.FS.Stream × IO.FS.Stream) := do
+private def spawnTestServer (framing : Framing.Spec) : IO (SpawnedServer × IO.FS.Stream × IO.FS.Stream) := do
   let child ← IO.Process.spawn {
-    cmd := "lake"
-    args := #[("exe" : String), "test_server", "--", serverFrameArg frameSpec]
+    cmd := ".lake/build/bin/test_server"
+    args := #[serverFrameArg framing]
     stdin := .piped
     stdout := .piped
     stderr := .inherit
@@ -67,10 +69,10 @@ private def objParams (fields : List (String × Json)) : Json.Structured :=
   | .obj kvs => .obj kvs
   | _ => .obj {}
 
-private def runClientTest (frameSpec : FrameSpec) : IO Unit := do
-  let (child, childStdin, childStdout) ← spawnTestServer frameSpec
+private def runClientTest (framing : Framing.Spec) : IO Unit := do
+  let (child, childStdin, childStdout) ← spawnTestServer framing
   let transport ← Async.block <|
-    clientTransportFromStreams childStdout childStdin frameSpec silentLogger
+    clientTransportFromStreams childStdout childStdin framing silentLogger
   let client ← Async.block <| getClient transport
   try
     let echoParams := objParams
@@ -112,9 +114,9 @@ end LeanWorkerTest
 
 public def main (args : List String) : IO UInt32 := do
   match LeanWorkerTest.parseFrameSpec args with
-  | .ok frameSpec =>
+  | .ok framing =>
     try
-      LeanWorkerTest.runClientTest frameSpec
+      LeanWorkerTest.runClientTest framing
       return 0
     catch err =>
       let stderr ← IO.getStderr

--- a/LeanWorkerTest/TestClient.lean
+++ b/LeanWorkerTest/TestClient.lean
@@ -49,10 +49,9 @@ private def serverFrameArg (framing : Framing.Spec) : String :=
   | .contentLength => "--header"
 
 private def spawnTestServer (framing : Framing.Spec) : IO (SpawnedServer × IO.FS.Stream × IO.FS.Stream) := do
-  -- This assumes the test is run from the repo root after `lake build`.
   let child ← IO.Process.spawn {
-    cmd := ".lake/build/bin/test_server"
-    args := #[serverFrameArg framing]
+    cmd := "lake"
+    args := #[("exe" : String), "test_server", "--", serverFrameArg framing]
     stdin := .piped
     stdout := .piped
     stderr := .inherit

--- a/LeanWorkerTest/TestServer.lean
+++ b/LeanWorkerTest/TestServer.lean
@@ -2,6 +2,7 @@ module
 
 import LeanWorker.Server
 import LeanWorker.Transport
+import LeanWorker.Framing
 
 namespace LeanWorkerTest
 
@@ -9,6 +10,7 @@ open Lean
 open LeanWorker
 open Server
 open Transport
+open Framing
 
 private def echo : StatelessHandler Unit Json.Structured (Option Json.Structured) :=
   fun param =>
@@ -23,8 +25,8 @@ private def testServer (transport : Transport) : Server Unit Unit where
   notifications := .empty
   transport := transport
 
-private def parseFrameSpec (args : List String) : Except String FrameSpec := do
-  let mut selected? : Option FrameSpec := none
+private def parseFrameSpec (args : List String) : Except String Framing.Spec := do
+  let mut selected? : Option Framing.Spec := none
   for arg in args do
     match arg with
     | "--" =>
@@ -50,9 +52,9 @@ private def parseFrameSpec (args : List String) : Except String FrameSpec := do
   return selected?.getD .newline
 
 open Std Internal IO Async in
-private def runTestServer (frameSpec : FrameSpec) : Async Unit := do
+private def runTestServer (framing : Framing.Spec) : Async Unit := do
   let stderr ← IO.getStderr
-  let transport ← serverTransportFromStdio frameSpec fun lvl msg => do
+  let transport ← serverTransportFromStdio framing fun lvl msg => do
     stderr.putStrLn s!"[{repr lvl}] {msg}"
   let server := testServer transport
   Server.run server () <| ← Std.Mutex.new ()
@@ -61,8 +63,8 @@ end LeanWorkerTest
 
 public def main (args : List String) : IO UInt32 := do
   match LeanWorkerTest.parseFrameSpec args with
-  | .ok frameSpec =>
-    LeanWorkerTest.runTestServer frameSpec |>.block
+  | .ok framing =>
+    LeanWorkerTest.runTestServer framing |>.block
     return 0
   | .error message =>
     let stderr ← IO.getStderr

--- a/LeanWorkerTest/TestTcp.lean
+++ b/LeanWorkerTest/TestTcp.lean
@@ -1,0 +1,128 @@
+module
+
+import LeanWorker.Client
+import LeanWorker.Server
+import LeanWorker.Transport
+import LeanWorker.Framing
+import Std.Internal.Async.TCP
+
+namespace LeanWorkerTest
+
+open Lean
+open LeanWorker
+open Client
+open Server
+open Transport
+open Framing
+open JsonRpc
+open Std.Net
+open Std.Internal.IO.Async
+
+private def echo : StatelessHandler Unit Json.Structured (Option Json.Structured) :=
+  fun param =>
+    return param
+
+private def handlers : HandlerRegistry Unit Unit :=
+  .empty
+    |>.addStateless "echo" echo
+
+private def testServer (transport : Transport) : Server Unit Unit where
+  handlers := handlers
+  notifications := .empty
+  transport := transport
+
+private def parseFrameSpec (args : List String) : Except String Framing.Spec := do
+  let mut selected? : Option Framing.Spec := none
+  for arg in args do
+    match arg with
+    | "--" =>
+      pure ()
+    | "--newline" =>
+      match selected? with
+      | none =>
+        selected? := some .newline
+      | some .newline =>
+        pure ()
+      | some .contentLength =>
+        throw "cannot use both --newline and --header"
+    | "--header" =>
+      match selected? with
+      | none =>
+        selected? := some .contentLength
+      | some .contentLength =>
+        pure ()
+      | some .newline =>
+        throw "cannot use both --newline and --header"
+    | _ =>
+      throw s!"unknown flag: {arg}"
+  return selected?.getD .newline
+
+private def runEAsync (action : EAsync Error α) : IO (Except Error α) :=
+  EIO.toIO' <| EAsync.block action
+
+private def objParams (fields : List (String × Json)) : Json.Structured :=
+  match Json.mkObj fields with
+  | .obj kvs => .obj kvs
+  | _ => .obj {}
+
+private def loopbackAddress (port : UInt16) : SocketAddress :=
+  .v4 { addr := IPv4Addr.ofParts 127 0 0 1, port := port }
+
+private def runClientAssertions (client : Client) : IO Unit := do
+  let echoParams := objParams
+    [
+      ("message", Json.str "hello from test_tcp"),
+      ("count", toJson (3 : Nat))
+    ]
+  let echoResult ← runEAsync <| client.request "echo" (some echoParams)
+  match echoResult with
+  | .ok result =>
+    if result != toJson echoParams then
+      throw <| IO.userError s!"unexpected echo result: {Json.compress result}"
+  | .error err =>
+    throw <| IO.userError s!"echo request failed: {err.code}: {err.message}"
+
+  let missingResult ← runEAsync <| client.request "missingMethod" none
+  match missingResult with
+  | .ok _ =>
+    throw <| IO.userError "expected method-not-found error"
+  | .error err =>
+    if err.code != Error.methodNotFound.code then
+      throw <| IO.userError s!"unexpected error code: {err.code}"
+
+private def runTcpTest (framing : Framing.Spec) : IO Unit := do
+  let serverSocket ← TCP.Socket.Server.mk
+  serverSocket.bind (loopbackAddress 0)
+  serverSocket.listen 16
+  let localAddr ← serverSocket.getSockName
+  let serverTask ← Async.block <| async do
+    let socket ← serverSocket.accept
+    let transport ← serverTransportFromAcceptedTcpSocket socket framing silentLogger
+    let server := testServer transport
+    Server.run server () <| ← Std.Mutex.new ()
+  let transport ← Async.block <|
+    clientTransportFromTcpAddress localAddr framing silentLogger
+  let client ← Async.block <| getClient transport
+  try
+    runClientAssertions client
+  finally
+    Async.block client.shutdown
+    Async.block <| await serverTask
+
+end LeanWorkerTest
+
+public def main (args : List String) : IO UInt32 := do
+  match LeanWorkerTest.parseFrameSpec args with
+  | .ok framing =>
+    try
+      LeanWorkerTest.runTcpTest framing
+      return 0
+    catch err =>
+      let stderr ← IO.getStderr
+      stderr.putStrLn s!"error: {err}"
+      return 1
+  | .error message =>
+    let stderr ← IO.getStderr
+    stderr.putStrLn s!"error: {message}"
+    stderr.putStrLn "usage: lake exe test_tcp -- [--newline | --header]"
+    return 1

--- a/LeanWorkerTest/TestTransportCore.lean
+++ b/LeanWorkerTest/TestTransportCore.lean
@@ -1,0 +1,79 @@
+module
+
+import LeanWorker.Transport
+import LeanWorker.Framing
+
+namespace LeanWorkerTest
+
+open Lean
+open LeanWorker
+open Transport
+open Framing
+open JsonRpc
+open Std.Internal.IO.Async
+
+private def encodeJsonPayload (json : Json) : ByteArray :=
+  (Json.compress json).toUTF8
+
+private def byteSourceOfChunks (chunksRef : IO.Ref (List ByteArray)) : ByteSource where
+  recv? _ :=
+    chunksRef.modifyGet fun chunks =>
+      match chunks with
+      | [] => (none, [])
+      | chunk :: rest => (some chunk, rest)
+
+private def nullByteSink : ByteSink where
+  send _ := pure ()
+
+private def recvInbox
+    (transport : LeanWorker.Transport.Transport) : IO (Option (Except Error Json)) :=
+  Async.block do
+    await <| ← transport.inbox.recv
+
+private def runContentLengthPrefixErrorTest : IO Unit := do
+  let validJson := Json.mkObj [("kind", Json.str "ok")]
+  let validFrame := Framing.encode .contentLength (encodeJsonPayload validJson)
+  let malformedHeader := "Content-Length: nope\r\n\r\n".toUTF8
+  let chunksRef ← IO.mkRef [validFrame ++ malformedHeader]
+  let transport ← Async.block <|
+    transportFromByteStreams (byteSourceOfChunks chunksRef) nullByteSink .contentLength silentLogger
+  try
+    match ← recvInbox transport with
+    | some (.ok json) =>
+      if json != validJson then
+        throw <| IO.userError s!"unexpected first payload: {Json.compress json}"
+    | some (.error err) =>
+      throw <| IO.userError s!"expected first inbox item to be valid JSON, got error: {err.message}"
+    | none =>
+      throw <| IO.userError "expected first inbox item to be present"
+
+    match ← recvInbox transport with
+    | some (.error err) =>
+      if err.code != Error.parseError.code then
+        throw <| IO.userError s!"unexpected error code: {err.code}"
+    | some (.ok json) =>
+      throw <| IO.userError s!"expected framing error after first payload, got: {Json.compress json}"
+    | none =>
+      throw <| IO.userError "expected second inbox item to be a framing error"
+
+    match ← recvInbox transport with
+    | none =>
+      pure ()
+    | some (.ok json) =>
+      throw <| IO.userError s!"expected inbox to be closed, got JSON: {Json.compress json}"
+    | some (.error err) =>
+      throw <| IO.userError s!"expected inbox to be closed, got error: {err.message}"
+  finally
+    Async.block <| LeanWorker.Transport.closeOrLog transport.log "test outbox" transport.outbox
+    Async.block <| LeanWorker.Transport.closeOrLog transport.log "test inbox" transport.inbox
+
+end LeanWorkerTest
+
+public def main (_args : List String) : IO UInt32 := do
+  try
+    LeanWorkerTest.runContentLengthPrefixErrorTest
+    return 0
+  catch err =>
+    let stderr ← IO.getStderr
+    stderr.putStrLn s!"error: {err}"
+    return 1

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -21,6 +21,10 @@ lean_exe test_server where
 lean_exe test_client where
   root := `LeanWorkerTest.TestClient
 
+@[default_target]
+lean_exe test_tcp where
+  root := `LeanWorkerTest.TestTcp
+
 module_facet module_metadata mod : Json := do
   let olean ← (← mod.olean.fetch).await
   let (data, _) ← Lean.readModuleData olean

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -25,6 +25,10 @@ lean_exe test_client where
 lean_exe test_tcp where
   root := `LeanWorkerTest.TestTcp
 
+@[default_target]
+lean_exe test_transport_core where
+  root := `LeanWorkerTest.TestTransportCore
+
 module_facet module_metadata mod : Json := do
   let olean ← (← mod.olean.fetch).await
   let (data, _) ← Lean.readModuleData olean


### PR DESCRIPTION
## Summary
- move framing selection to `LeanWorker.Framing.Spec` and add framing codecs
- add a generic byte-stream transport core plus TCP transport constructors
- keep stdio transport working, add in-process TCP integration tests, and close the server outbox when the server loop finishes

## Testing
- `lake build`
- `lake exe test_client -- --newline`
- `lake exe test_client -- --header`
- `lake exe test_tcp -- --newline`
- `lake exe test_tcp -- --header`