### PR TITLE
Refactor stdio transport to use byte streams

### DIFF
--- a/LeanWorker/Transport/Stdio.lean
+++ b/LeanWorker/Transport/Stdio.lean
@@ -1,204 +1,39 @@
 module
 
 public import LeanWorker.Transport.Core
-public import LeanWorker.Framing
-public import LeanWorker.JsonRpc.Parse
-public import Std.Internal.Async.Basic
 
 public section
 
 namespace LeanWorker
 namespace Transport
 
-open Lean
-open JsonRpc
 open Std.Internal.IO.Async
 
-private def readChunkSize : Nat := 4096
-
-private def decodeJsonPayload (payload : ByteArray) : Except Error Json := do
-  let text ←
-    match String.fromUTF8? payload with
-    | some text => Except.ok text
-    | none =>
-      throw <| Error.withData Error.parseError (Json.str "invalid UTF-8 in JSON payload")
-  parseJson text
-
-private def encodeJsonPayload (json : Json) : ByteArray :=
-  (Json.compress json).toUTF8
-
-private def writeFramedJson
-    (writeStream : IO.FS.Stream)
-    (framing : Framing.Spec)
-    (json : Json) : IO Unit := do
-  let payload := encodeJsonPayload json
-  let bytes := Framing.encode framing payload
-  writeStream.write bytes
-  writeStream.flush
-
-private def emitPayloads
-    (log : LogLevel → String → IO Unit)
-    (inbox : Std.CloseableChannel (Except Error Json))
-    (payloads : Array ByteArray) : Async Bool := do
-  let mut continueLoop := true
-  for payload in payloads do
-    if continueLoop then
-      match decodeJsonPayload payload with
-      | .ok json =>
-        let sent ← LeanWorker.Transport.sendOrLog log "json inbox" inbox (.ok json)
-        if !sent then
-          continueLoop := false
-      | .error err =>
-        LeanWorker.Transport.logError log
-          s!"json decode error: {LeanWorker.Transport.errorToString err}"
-        let sent ← LeanWorker.Transport.sendOrLog log "json inbox" inbox (.error err)
-        if !sent then
-          continueLoop := false
-  return continueLoop
-
-private def parseContentLengthFromHeaderLines
-    (headerLines : List String) : Except Error Nat := do
-  let headers ← headerLines.mapM Framing.parseHeaderLine
-  Framing.parseContentLength headers
-
-private partial def readHeaderLines
-    (readStream : IO.FS.Stream)
-    (acc : List String := [])
-    (sawBytes : Bool := false) : Async (Except Error (Option (List String))) := do
-  let line := (← readStream.getLine)
-  if line.isEmpty then
-    if sawBytes then
-      return .error <| Framing.framingError "unexpected EOF while reading headers"
+private def byteSourceOfStream (stream : IO.FS.Stream) : ByteSource where
+  recv? _ := do
+    -- Pipe-backed `IO.FS.Stream`s behave more predictably for stdio when read
+    -- incrementally, and the shared transport core already buffers framed input.
+    let chunk ← stream.read 1
+    if chunk.isEmpty then
+      return none
     else
-      return .ok none
-  let normalized := line.trimAscii.toString
-  if normalized.isEmpty then
-    return .ok <| some acc.reverse
-  else
-    readHeaderLines readStream (normalized :: acc) true
+      return some chunk
 
-private partial def readBodyBytes
-    (readStream : IO.FS.Stream)
-    (remaining : Nat)
-    (buffer : ByteArray := ByteArray.empty) : Async (Except Error ByteArray) := do
-  if remaining == 0 then
-    return .ok buffer
-  let nextChunk := Nat.min remaining readChunkSize
-  let chunk ← readStream.read (USize.ofNat nextChunk)
-  if chunk.size == 0 then
-    return .error <| Framing.framingError "unexpected EOF while reading framed body"
-  readBodyBytes readStream (remaining - chunk.size) (buffer ++ chunk)
-
-private partial def readNewlineLoop
-    (readStream : IO.FS.Stream)
-    (log : LogLevel → String → IO Unit)
-    (inbox : Std.CloseableChannel (Except Error Json))
-    (buffer : ByteArray := ByteArray.empty) : Async Unit := do
-  let line := (← readStream.getLine)
-  if line.isEmpty then
-    if buffer.isEmpty then
-      LeanWorker.Transport.closeOrLog log "json inbox" inbox
-    else
-      let sent ← LeanWorker.Transport.sendOrLog log "json inbox" inbox (.error <| Framing.eofError .newline)
-      if sent then
-        LeanWorker.Transport.closeOrLog log "json inbox" inbox
-  else
-    let buffer := buffer ++ line.toUTF8
-    match Framing.decode .newline buffer with
-    | .error err =>
-      LeanWorker.Transport.logError log
-        s!"framing decode error: {LeanWorker.Transport.errorToString err}"
-      let sent ← LeanWorker.Transport.sendOrLog log "json inbox" inbox (.error err)
-      if sent then
-        readNewlineLoop readStream log inbox ByteArray.empty
-    | .ok (payloads, rest) =>
-      let keepReading ← emitPayloads log inbox payloads
-      if keepReading then
-        readNewlineLoop readStream log inbox rest
-
-private partial def readContentLengthLoop
-    (readStream : IO.FS.Stream)
-    (log : LogLevel → String → IO Unit)
-    (inbox : Std.CloseableChannel (Except Error Json)) : Async Unit := do
-  match ← readHeaderLines readStream with
-  | .ok none =>
-    LeanWorker.Transport.closeOrLog log "json inbox" inbox
-  | .error err =>
-    LeanWorker.Transport.logError log
-      s!"framing decode error: {LeanWorker.Transport.errorToString err}"
-    let sent ← LeanWorker.Transport.sendOrLog log "json inbox" inbox (.error err)
-    if sent then
-      LeanWorker.Transport.closeOrLog log "json inbox" inbox
-  | .ok (some headerLines) =>
-    match parseContentLengthFromHeaderLines headerLines with
-    | .error err =>
-      LeanWorker.Transport.logError log
-        s!"framing decode error: {LeanWorker.Transport.errorToString err}"
-      let sent ← LeanWorker.Transport.sendOrLog log "json inbox" inbox (.error err)
-      if sent then
-        LeanWorker.Transport.closeOrLog log "json inbox" inbox
-    | .ok contentLength =>
-      match ← readBodyBytes readStream contentLength with
-      | .error err =>
-        LeanWorker.Transport.logError log
-          s!"framing decode error: {LeanWorker.Transport.errorToString err}"
-        let sent ← LeanWorker.Transport.sendOrLog log "json inbox" inbox (.error err)
-        if sent then
-          LeanWorker.Transport.closeOrLog log "json inbox" inbox
-      | .ok payload =>
-        let keepReading ← emitPayloads log inbox #[payload]
-        if keepReading then
-          readContentLengthLoop readStream log inbox
-
-private def readJsonLoop
-    (readStream : IO.FS.Stream)
-    (framing : Framing.Spec)
-    (log : LogLevel → String → IO Unit)
-    (inbox : Std.CloseableChannel (Except Error Json)) : Async Unit :=
-  match framing with
-  | .newline => readNewlineLoop readStream log inbox
-  | .contentLength => readContentLengthLoop readStream log inbox
-
-private partial def writeJsonLoop
-    (writeStream : IO.FS.Stream)
-    (framing : Framing.Spec)
-    (outbox : Std.CloseableChannel Json) : Async Unit := do
-  match ← await <| ← outbox.recv with
-  | none =>
-    return
-  | some json =>
-    writeFramedJson writeStream framing json
-    writeJsonLoop writeStream framing outbox
-
-private def transportFromStreamsCore
-    (readStream writeStream : IO.FS.Stream)
-    (framing : Framing.Spec)
-    (log : LogLevel → String → IO Unit) : Async Transport := do
-  let inbox : Std.CloseableChannel (Except Error Json) ← Std.CloseableChannel.new
-  let outbox : Std.CloseableChannel Json ← Std.CloseableChannel.new
-
-  let _readerTask : AsyncTask Unit ← async do
-    try
-      readJsonLoop readStream framing log inbox
-    catch err =>
-      LeanWorker.Transport.logError log s!"json read task error: {err}"
-      LeanWorker.Transport.closeOrLog log "json inbox" inbox
-
-  let _writerTask : AsyncTask Unit ← async do
-    try
-      writeJsonLoop writeStream framing outbox
-    catch err =>
-      LeanWorker.Transport.logError log s!"json write task error: {err}"
-      LeanWorker.Transport.closeOrLog log "json outbox" outbox
-      LeanWorker.Transport.closeOrLog log "json inbox" inbox
-
-  return { inbox, outbox, log }
+private def byteSinkOfStream (stream : IO.FS.Stream) : ByteSink where
+  send bytes :=
+    stream.write bytes
+  flush :=
+    stream.flush
 
 def transportFromStreams
     (readStream writeStream : IO.FS.Stream)
     (framing : Framing.Spec := .newline)
     (log : LogLevel → String → IO Unit := silentLogger) : Async Transport :=
-  transportFromStreamsCore readStream writeStream framing log
+  transportFromByteStreams
+    (byteSourceOfStream readStream)
+    (byteSinkOfStream writeStream)
+    framing
+    log
 
 def serverTransportFromStreams
     (readStream writeStream : IO.FS.Stream)


### PR DESCRIPTION
## Summary
- refactor `LeanWorker/Transport/Stdio.lean` into a thin `IO.FS.Stream` adapter over `transportFromByteStreams`
- remove the duplicated stdio-specific framing/JSON transport loops while keeping the existing public stdio/stream constructors

## Validation
- `lake build`
- `lake exe test_transport_core`
- `lake exe test_tcp -- --newline`
- `lake exe test_tcp -- --header`
- `lake exe test_client -- --newline`
- `lake exe test_client -- --header`
